### PR TITLE
Fix/apple empty playlist

### DIFF
--- a/src/components/library/TrackList.tsx
+++ b/src/components/library/TrackList.tsx
@@ -78,7 +78,38 @@ const TrackRow: FC<{
   );
 };
 
+// Empty state component for empty playlists
+const EmptyPlaylistState: FC = () => (
+  <div className="flex flex-col items-center justify-center py-16 text-center">
+    {/* Simple playlist SVG illustration */}
+    <svg
+      width="96"
+      height="96"
+      viewBox="0 0 96 96"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className="mb-6 text-indigo-400 dark:text-indigo-500"
+      aria-hidden="true"
+      role="img"
+    >
+      <rect x="12" y="24" width="72" height="48" rx="8" fill="currentColor" fillOpacity="0.08" />
+      <rect x="24" y="36" width="48" height="8" rx="2" fill="currentColor" fillOpacity="0.18" />
+      <rect x="24" y="50" width="32" height="8" rx="2" fill="currentColor" fillOpacity="0.18" />
+      <circle cx="72" cy="54" r="8" fill="currentColor" fillOpacity="0.18" />
+      <circle cx="72" cy="54" r="4" fill="currentColor" fillOpacity="0.35" />
+    </svg>
+    <div className="text-lg font-semibold text-slate-700 dark:text-slate-200">
+      This playlist seems to be empty
+    </div>
+  </div>
+);
+
 export const TrackList: FC<TrackListProps> = ({ tracks, selection = new Set(), playlist }) => {
+  // Show empty state if no tracks
+  if (!tracks || tracks.length === 0) {
+    return <EmptyPlaylistState />;
+  }
+
   return (
     <div className="relative bg-transparent dark:bg-transparent" role="tracklist">
       {/* Header */}

--- a/src/config/services.ts
+++ b/src/config/services.ts
@@ -47,7 +47,20 @@ export const SERVICES: Record<string, ServiceConfig> = {
     image: AppleMusicLogo,
     color: "#FA243C",
     status: "Available",
-    getPlaylistUrl: (id: string) => `https://music.apple.com/library/playlist/${id}`,
+    getPlaylistUrl: (id: string) => {
+      try {
+        if (typeof window !== "undefined" && window.MusicKit) {
+          const music = window.MusicKit.getInstance();
+          const storefrontId = music?.storefrontId;
+          if (storefrontId) {
+            return `https://music.apple.com/${storefrontId}/library/playlist/${id}`;
+          }
+        }
+      } catch (error) {
+        console.error("Error retrieving Apple Music storefront ID:", error);
+      }
+      return `https://music.apple.com/library/playlist/${id}`;
+    },
   },
   amazonMusic: {
     id: "amazonMusic",

--- a/src/hooks/usePlaylistTracks.ts
+++ b/src/hooks/usePlaylistTracks.ts
@@ -9,6 +9,9 @@ interface UsePlaylistTracksReturn {
   error: string | null;
 }
 
+// Module-level Set to track which playlist IDs have been fetched
+const fetchedPlaylists = new Set<string>();
+
 export const usePlaylistTracks = (playlistId: string): UsePlaylistTracksReturn => {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -25,6 +28,11 @@ export const usePlaylistTracks = (playlistId: string): UsePlaylistTracksReturn =
       const existingPlaylist = state.playlists.get(playlistId);
       if (!existingPlaylist) {
         setError("Playlist not found");
+        return;
+      }
+
+      // If we've already fetched for this playlist, do not fetch again (prevents infinite loop)
+      if (fetchedPlaylists.has(playlistId)) {
         return;
       }
 
@@ -55,6 +63,8 @@ export const usePlaylistTracks = (playlistId: string): UsePlaylistTracksReturn =
         console.error("Error fetching playlist tracks:", err);
         setError(errorMessage);
       } finally {
+        // Mark this playlist as fetched, regardless of success or failure, to prevent infinite loop
+        fetchedPlaylists.add(playlistId);
         if (isMounted) {
           setIsLoading(false);
         }

--- a/src/lib/services/apple/api.ts
+++ b/src/lib/services/apple/api.ts
@@ -16,6 +16,7 @@ import { AUTH_STORAGE_KEYS, type AuthData, setServiceType } from "@/lib/auth/con
 
 interface MusicKitInstance {
   authorize: () => Promise<string>;
+  storefrontId?: string;
   api: {
     search: (
       term: string,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a visually styled empty state for playlists with no tracks, providing clear feedback to users when a playlist is empty.

- **Improvements**
  - Enhanced Apple Music playlist URL generation to include the user's storefront ID when available, improving accuracy of shared links.
  - Improved error handling and efficiency when fetching playlist tracks, reducing redundant network requests and preventing infinite loops.
  - 404 errors when fetching playlist tracks can now be treated as empty results, preventing unnecessary error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->