### PR TITLE
feat: added backlinks on liked and albums

### DIFF
--- a/src/__tests__/app/library/[source]/[target]/albums/page.test.tsx
+++ b/src/__tests__/app/library/[source]/[target]/albums/page.test.tsx
@@ -10,6 +10,16 @@ mockReactSuspense();
 import { useMatching, resetMocks as resetMatchingMocks } from "@/__mocks__/hooks/useMatching";
 vi.mock("@/hooks/useMatching", () => ({ useMatching }));
 
+// Mock PlayOnButton component to avoid dependency issues in tests
+vi.mock("@/components/shared/PlayOnButton", () => ({
+  PlayOnButton: () => null,
+}));
+
+// Mock getServiceType to return a default value (e.g., 'spotify')
+vi.mock("@/lib/auth/constants", () => ({
+  getServiceType: () => "spotify",
+}));
+
 // Regular imports
 import React from "react";
 import { render, screen, within } from "@testing-library/react";
@@ -53,7 +63,8 @@ describe("AlbumsPage", () => {
       </TestWrapper>
     );
 
-    expect(screen.getByText("3 albums • 1 unmatched")).toBeInTheDocument();
+    expect(screen.getByText("3 albums")).toBeInTheDocument();
+    expect(screen.getByText(/1 unmatched/i)).toBeInTheDocument();
   });
 
   it("renders album details correctly", () => {

--- a/src/__tests__/app/library/[source]/[target]/liked/page.test.tsx
+++ b/src/__tests__/app/library/[source]/[target]/liked/page.test.tsx
@@ -10,6 +10,16 @@ mockReactSuspense();
 import { useMatching, resetMocks as resetMatchingMocks } from "@/__mocks__/hooks/useMatching";
 vi.mock("@/hooks/useMatching", () => ({ useMatching }));
 
+// Mock PlayOnButton component to avoid dependency issues in tests
+vi.mock("@/components/shared/PlayOnButton", () => ({
+  PlayOnButton: () => null,
+}));
+
+// Mock getServiceType to return a default value (e.g., 'spotify')
+vi.mock("@/lib/auth/constants", () => ({
+  getServiceType: () => "spotify",
+}));
+
 // Regular imports
 import React from "react";
 import { render, screen, within } from "@testing-library/react";
@@ -52,7 +62,8 @@ describe("LikedSongsPage", () => {
       </TestWrapper>
     );
 
-    expect(screen.getByText(/1 tracks unmatched/i)).toBeInTheDocument();
+    expect(screen.getByText("5 tracks")).toBeInTheDocument();
+    expect(screen.getByText(/1 unmatched/i)).toBeInTheDocument();
   });
 
   it("renders track details correctly", () => {

--- a/src/app/library/[source]/[target]/liked/_components/LikedSongs.tsx
+++ b/src/app/library/[source]/[target]/liked/_components/LikedSongs.tsx
@@ -4,6 +4,8 @@ import { FC, useEffect } from "react";
 import { useLibrary } from "@/contexts/LibraryContext";
 import { TrackList } from "@/components/library/TrackList";
 import { useItemTitle } from "@/contexts/ItemTitleContext";
+import { PlayOnButton } from "@/components/shared/PlayOnButton";
+import { LikedSongsIcon } from "@/components/icons/LikedSongsIcon";
 
 export const LikedSongs: FC = () => {
   const { state } = useLibrary();
@@ -26,25 +28,45 @@ export const LikedSongs: FC = () => {
     return track.status === "unmatched" ? count + 1 : count;
   }, 0);
 
+  // Placeholder artwork for Liked Songs (now uses LikedSongsIcon)
+  const likedArtwork = (
+    <div className="flex h-48 w-48 items-center justify-center rounded-lg bg-gradient-to-br from-indigo-600 to-indigo-300">
+      <LikedSongsIcon className="h-20 w-20 text-white drop-shadow-lg dark:text-indigo-100" />
+    </div>
+  );
+
   return (
     <div className="space-y-6">
-      {/* Header */}
-      <div>
-        <h1 className="text-2xl font-bold text-indigo-900 dark:text-indigo-50">Liked Songs</h1>
-        <p className="text-sm text-indigo-700 dark:text-indigo-300">
-          {state.likedSongs.size} tracks
-        </p>
+      {/* Header: visually matches Playlist header */}
+      <div className="flex flex-col items-center lg:flex-row lg:gap-4">
+        {/* Artwork placeholder */}
+        <div className="w-48 overflow-hidden rounded-lg bg-indigo-50/50 dark:bg-indigo-950/20">
+          {likedArtwork}
+        </div>
+        <div className="mt-6 min-w-0 flex-1 text-center lg:mt-0 lg:text-left">
+          {/* Title and subtitle are wrapped for desktop-only left padding */}
+          <div className="lg:pl-4">
+            <h1 className="w-full max-w-full whitespace-normal break-words text-2xl font-bold text-indigo-900 lg:text-3xl dark:text-indigo-50">
+              Liked Songs
+            </h1>
+            <p className="mt-2 text-sm text-indigo-700 dark:text-indigo-300">
+              {state.likedSongs.size} tracks
+              {unmatchedCount > 0 && (
+                <span className="ml-2 text-red-500 dark:text-red-400">
+                  • {unmatchedCount} unmatched
+                </span>
+              )}
+            </p>
+          </div>
+          {/* Play on [service] button for liked songs */}
+          <div className="mt-4 lg:mt-6">
+            <PlayOnButton type="liked" />
+          </div>
+        </div>
       </div>
 
       {/* Content */}
       <div>
-        {/* Unmatched count info */}
-        {unmatchedCount > 0 && (
-          <p className="mb-4 text-sm text-red-500 dark:text-red-400">
-            {unmatchedCount} tracks unmatched
-          </p>
-        )}
-
         {/* Track List */}
         <TrackList tracks={Array.from(state.likedSongs)} selection={new Set()} />
       </div>

--- a/src/app/library/[source]/[target]/playlist/[id]/_components/Playlist.tsx
+++ b/src/app/library/[source]/[target]/playlist/[id]/_components/Playlist.tsx
@@ -48,20 +48,23 @@ export const Playlist: FC<PlaylistProps> = ({ playlistId }) => {
   return (
     <div className="space-y-6">
       {/* Playlist Header */}
-      <div className="flex flex-col items-center lg:flex-row lg:gap-8">
+      <div className="flex flex-col items-center lg:flex-row lg:gap-4">
         <div className="w-48 overflow-hidden rounded-lg bg-indigo-50/50 dark:bg-indigo-950/20">
           <ArtworkImage src={playlist.artwork} alt={playlist.name} size={192} type="playlist" />
         </div>
         <div className="mt-6 min-w-0 flex-1 text-center lg:mt-0 lg:text-left">
-          {/* Allow playlist name to wrap and break long words instead of truncating */}
-          <h1 className="w-full max-w-full whitespace-normal break-words text-2xl font-bold text-indigo-900 lg:text-3xl dark:text-indigo-50">
-            {playlist.name}
-          </h1>
-          <p className="mt-2 text-sm text-indigo-700 dark:text-indigo-300">
-            {playlist.tracks.length} tracks • {unmatchedCount} unmatched
-          </p>
+          {/* Title and subtitle are wrapped for desktop-only left padding */}
+          <div className="lg:pl-4">
+            {/* Allow playlist name to wrap and break long words instead of truncating */}
+            <h1 className="w-full max-w-full whitespace-normal break-words text-2xl font-bold text-indigo-900 lg:text-3xl dark:text-indigo-50">
+              {playlist.name}
+            </h1>
+            <p className="mt-2 text-sm text-indigo-700 dark:text-indigo-300">
+              {playlist.tracks.length} tracks • {unmatchedCount} unmatched
+            </p>
+          </div>
           <div className="mt-4 lg:mt-6">
-            <PlayOnButton playlistId={playlist.id} />
+            <PlayOnButton type="playlist" playlistId={playlist.id} />
           </div>
         </div>
       </div>

--- a/src/components/icons/LikedSongsIcon.tsx
+++ b/src/components/icons/LikedSongsIcon.tsx
@@ -1,0 +1,22 @@
+import { FC, SVGProps } from "react";
+
+/**
+ * LikedSongsIcon renders a heart SVG used for Liked Songs artwork and UI elements.
+ * Accepts all standard SVG props for flexibility.
+ */
+export const LikedSongsIcon: FC<SVGProps<SVGSVGElement>> = ({ className = "", ...props }) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    fill="currentColor"
+    aria-hidden="true"
+    className={className}
+    {...props}
+  >
+    <path
+      fillRule="evenodd"
+      d="M12.001 4.529c2.349-2.532 6.15-2.532 8.498 0 2.349 2.532 2.349 6.64 0 9.172l-7.071 7.627a1.25 1.25 0 01-1.854 0l-7.071-7.627c-2.349-2.532-2.349-6.64 0-9.172 2.348-2.532 6.149-2.532 8.498 0z"
+      clipRule="evenodd"
+    />
+  </svg>
+);

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -11,6 +11,7 @@ import { MusicService, IPlaylist } from "@/types";
 import { fetchPlaylistTracks } from "@/lib/musicApi";
 import React from "react";
 import { fetchingPlaylists } from "@/components/shared/TransferButton";
+import { LikedSongsIcon } from "@/components/icons/LikedSongsIcon";
 
 // Main component
 export const LibrarySidebar: FC = () => {
@@ -198,9 +199,7 @@ export const LibrarySidebar: FC = () => {
           />
         </div>
         <div className="relative flex h-12 w-12 items-center justify-center rounded-lg bg-gradient-to-br from-indigo-600 to-indigo-300">
-          <svg className="h-5 w-5 text-white" fill="currentColor" viewBox="0 0 24 24">
-            <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z" />
-          </svg>
+          <LikedSongsIcon className="h-5 w-5 text-white" />
           {/* Show progress if matching liked songs */}
           {currentTask && currentTask.type === "likedSongs" && isMatching && (
             <CircularProgress
@@ -258,7 +257,11 @@ export const LibrarySidebar: FC = () => {
           <div className="relative overflow-hidden rounded-lg">
             <ArtworkImage
               src={Array.from(state.albums ?? [])[0]?.artwork}
-              alt="First Album"
+              multiSrc={Array.from(state.albums ?? [])
+                .slice(0, 4)
+                .map(a => a.artwork)
+                .filter((a): a is string => Boolean(a))}
+              alt="Albums artwork"
               type="album"
               className="rounded-lg"
             />

--- a/src/components/library/AlbumList.tsx
+++ b/src/components/library/AlbumList.tsx
@@ -6,6 +6,7 @@ import { useIsVisible } from "@/hooks/useIsVisible";
 import { StatusIcon } from "@/components/shared/StatusIcon";
 import type { IAlbum } from "@/types";
 import { useItemTitle } from "@/contexts/ItemTitleContext";
+import { PlayOnButton } from "@/components/shared/PlayOnButton";
 
 interface AlbumItemProps {
   album: IAlbum;
@@ -70,18 +71,56 @@ export const AlbumList: FC = () => {
 
   if (!state.albums) return null;
 
-  const unmatchedCount = Array.from(state.albums).reduce((count, album) => {
+  const albumsArray = Array.from(state.albums);
+  const firstAlbumArtwork = albumsArray[0]?.artwork;
+  const albumArtworks = albumsArray
+    .slice(0, 4)
+    .map(a => a.artwork)
+    .filter((a): a is string => Boolean(a));
+  const unmatchedCount = albumsArray.reduce((count, album) => {
     return album.status === "unmatched" ? count + 1 : count;
   }, 0);
 
+  // Placeholder artwork if no albums exist
+  const artwork =
+    albumArtworks.length > 1 ? (
+      <ArtworkImage multiSrc={albumArtworks} alt="Albums artwork" size={192} type="album" />
+    ) : firstAlbumArtwork ? (
+      <ArtworkImage src={firstAlbumArtwork} alt="First album artwork" size={192} type="album" />
+    ) : (
+      <div className="flex h-48 w-48 items-center justify-center rounded-lg bg-slate-100 dark:bg-slate-800" />
+    );
+
   return (
     <div className="space-y-6">
-      <div>
-        <h1 className="text-2xl font-bold text-indigo-900 dark:text-indigo-50">Albums</h1>
-        <p className="text-sm text-indigo-700 dark:text-indigo-300">
-          {state.albums.size} albums • {unmatchedCount} unmatched
-        </p>
+      {/* Header: visually matches Playlist/LikedSongs header */}
+      <div className="flex flex-col items-center lg:flex-row lg:gap-4">
+        {/* Artwork */}
+        <div className="w-48 overflow-hidden rounded-lg bg-indigo-50/50 dark:bg-indigo-950/20">
+          {artwork}
+        </div>
+        <div className="mt-6 min-w-0 flex-1 text-center lg:mt-0 lg:text-left">
+          {/* Title and subtitle are wrapped for desktop-only left padding */}
+          <div className="lg:pl-4">
+            <h1 className="w-full max-w-full whitespace-normal break-words text-2xl font-bold text-indigo-900 lg:text-3xl dark:text-indigo-50">
+              Albums
+            </h1>
+            <p className="mt-2 text-sm text-indigo-700 dark:text-indigo-300">
+              {state.albums.size} albums
+              {unmatchedCount > 0 && (
+                <span className="ml-2 text-red-500 dark:text-red-400">
+                  • {unmatchedCount} unmatched
+                </span>
+              )}
+            </p>
+          </div>
+          {/* Play on [service] button for albums */}
+          <div className="mt-4 lg:mt-6">
+            <PlayOnButton type="albums" />
+          </div>
+        </div>
       </div>
+      {/* Table header and album list */}
       <div className="relative bg-transparent dark:bg-transparent" role="albumlist">
         <div
           className="mb-4 grid grid-cols-[32px_1fr_32px] gap-2 border-b border-slate-200 bg-white/80 p-1.5 py-2 text-xs font-normal text-slate-500 backdrop-blur-sm dark:border-slate-700 dark:bg-slate-950/80 dark:text-slate-400"
@@ -96,7 +135,7 @@ export const AlbumList: FC = () => {
           </div>
         </div>
         <div className="space-y-2">
-          {Array.from(state.albums).map((album, index) => (
+          {albumsArray.map((album, index) => (
             <AlbumItem key={`${album.id}-${index}`} album={album} />
           ))}
         </div>

--- a/src/components/shared/ArtworkImage.tsx
+++ b/src/components/shared/ArtworkImage.tsx
@@ -12,6 +12,10 @@ interface ArtworkImageProps {
   type?: ArtworkType;
   className?: string;
   objectFit?: "cover" | "contain";
+  /**
+   * For albums grid: up to 4 artwork URLs to display as a grid.
+   */
+  multiSrc?: string[];
 }
 
 const FALLBACK_CONFIGS = {
@@ -55,11 +59,48 @@ export const ArtworkImage: React.FC<ArtworkImageProps> = ({
   type = "playlist",
   className = "",
   objectFit = "cover",
+  multiSrc,
 }) => {
   const baseClassName =
     "relative overflow-hidden rounded-md shadow-sm transition-transform duration-200";
   const finalClassName = `${baseClassName} ${className}`;
 
+  // Special grid for albums: up to 4 images
+  if (type === "album" && Array.isArray(multiSrc) && multiSrc.length > 1) {
+    // Only use up to 4 images
+    const images = multiSrc.slice(0, 4);
+    // Grid layout: 2x2 for 4, 1x2 for 2, 1x3 for 3
+    // Fallback to placeholder for missing images
+    return (
+      <div
+        style={{ width: size, height: size }}
+        className={`grid ${images.length > 2 ? "grid-cols-2 grid-rows-2" : "grid-cols-2 grid-rows-1"} gap-0.5 rounded-md bg-purple-100 dark:bg-purple-900/30 ${finalClassName}`}
+      >
+        {Array.from({ length: images.length < 4 ? images.length : 4 }).map((_, i) =>
+          images[i] ? (
+            <div key={i} className="relative h-full w-full">
+              <Image
+                src={images[i]}
+                alt={alt + ` ${i + 1}`}
+                fill
+                className={`object-${objectFit} rounded-[2px]`}
+                sizes={`${Math.floor(size / 2)}px`}
+              />
+            </div>
+          ) : (
+            <div
+              key={i}
+              className="flex h-full w-full items-center justify-center rounded-[2px] bg-purple-100 dark:bg-purple-900/30"
+            >
+              <span className="text-purple-300">?</span>
+            </div>
+          )
+        )}
+      </div>
+    );
+  }
+
+  // Fallback to single image or icon
   if (!src) {
     const fallback = FALLBACK_CONFIGS[type];
     return (

--- a/src/components/shared/PlayOnButton.tsx
+++ b/src/components/shared/PlayOnButton.tsx
@@ -2,19 +2,34 @@ import { FC } from "react";
 import { getServiceType } from "@/lib/auth/constants";
 import { SERVICES } from "@/config/services";
 
+// Supported types for PlayOnButton
 interface PlayOnButtonProps {
-  playlistId: string;
+  type: "playlist" | "liked" | "albums";
+  playlistId?: string; // Only required for playlist type
 }
 
-export const PlayOnButton: FC<PlayOnButtonProps> = ({ playlistId }) => {
+export const PlayOnButton: FC<PlayOnButtonProps> = ({ type, playlistId }) => {
   const serviceType = getServiceType("source");
   const service = SERVICES[serviceType as keyof typeof SERVICES];
 
   if (!service) return null;
 
+  // Determine the correct URL based on type
+  let url: string | null = null;
+  if (type === "playlist" && playlistId) {
+    url = service.getPlaylistUrl(playlistId);
+  } else if (type === "liked") {
+    url = service.getLikedSongsUrl();
+  } else if (type === "albums") {
+    url = service.getAlbumsUrl();
+  }
+
+  // Hide button if URL is not available
+  if (!url) return null;
+
   return (
     <a
-      href={service.getPlaylistUrl(playlistId)}
+      href={url}
       target="_blank"
       rel="noopener noreferrer"
       style={

--- a/src/config/services.ts
+++ b/src/config/services.ts
@@ -14,6 +14,8 @@ export interface ServiceConfig {
   color: string;
   status: "Available" | "Coming Soon" | "Beta" | "Maintenance";
   getPlaylistUrl: (id: string) => string;
+  getLikedSongsUrl: () => string | null;
+  getAlbumsUrl: () => string | null;
 }
 
 export const SERVICES: Record<string, ServiceConfig> = {
@@ -24,6 +26,8 @@ export const SERVICES: Record<string, ServiceConfig> = {
     color: "#1ed760",
     status: "Available",
     getPlaylistUrl: (id: string) => `https://open.spotify.com/playlist/${id}`,
+    getLikedSongsUrl: () => "https://open.spotify.com/collection/tracks",
+    getAlbumsUrl: () => "https://open.spotify.com/",
   },
   youtube: {
     id: "youtube",
@@ -32,6 +36,8 @@ export const SERVICES: Record<string, ServiceConfig> = {
     color: "#FF0000",
     status: "Available",
     getPlaylistUrl: (id: string) => `https://music.youtube.com/playlist?list=${id}`,
+    getLikedSongsUrl: () => "https://music.youtube.com/playlist?list=LM",
+    getAlbumsUrl: () => null,
   },
   deezer: {
     id: "deezer",
@@ -40,6 +46,16 @@ export const SERVICES: Record<string, ServiceConfig> = {
     color: "#A238FF",
     status: "Available",
     getPlaylistUrl: (id: string) => `https://www.deezer.com/playlist/${id}`,
+    getLikedSongsUrl: () => {
+      if (typeof window === "undefined") return null;
+      const userId = localStorage.getItem("deezer_user_id");
+      return userId ? `https://www.deezer.com/fr/profile/${userId}/loved` : null;
+    },
+    getAlbumsUrl: () => {
+      if (typeof window === "undefined") return null;
+      const userId = localStorage.getItem("deezer_user_id");
+      return userId ? `https://www.deezer.com/fr/profile/${userId}/albums` : null;
+    },
   },
   apple: {
     id: "apple",
@@ -61,6 +77,8 @@ export const SERVICES: Record<string, ServiceConfig> = {
       }
       return `https://music.apple.com/library/playlist/${id}`;
     },
+    getLikedSongsUrl: () => "https://music.apple.com/fr/library/songs",
+    getAlbumsUrl: () => "https://music.apple.com/fr/library/albums",
   },
   amazonMusic: {
     id: "amazonMusic",
@@ -69,6 +87,8 @@ export const SERVICES: Record<string, ServiceConfig> = {
     color: "#00A8E1",
     status: "Coming Soon",
     getPlaylistUrl: (id: string) => `https://music.amazon.com/playlists/${id}`,
+    getLikedSongsUrl: () => null,
+    getAlbumsUrl: () => null,
   },
   tidal: {
     id: "tidal",
@@ -77,6 +97,8 @@ export const SERVICES: Record<string, ServiceConfig> = {
     color: "#000000",
     status: "Coming Soon",
     getPlaylistUrl: (id: string) => `https://tidal.com/playlist/${id}`,
+    getLikedSongsUrl: () => null,
+    getAlbumsUrl: () => null,
   },
   pandora: {
     id: "pandora",
@@ -85,6 +107,8 @@ export const SERVICES: Record<string, ServiceConfig> = {
     color: "#3668FF",
     status: "Coming Soon",
     getPlaylistUrl: (id: string) => `https://www.pandora.com/playlist/${id}`,
+    getLikedSongsUrl: () => null,
+    getAlbumsUrl: () => null,
   },
 } as const;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a multi-artwork grid display for albums when multiple artworks are available.
  - Added a reusable heart icon for "Liked Songs" and updated its visual presentation.
  - Added a "Play on" button for playlists, liked songs, and albums, with dynamic linking based on music service and content type.

- **Enhancements**
  - Improved the layout and styling of album and liked songs headers for better visual consistency and responsiveness.
  - Sidebar and album artwork displays now use modular components for improved icon and image management.

- **Bug Fixes**
  - Updated tests to improve isolation and correctness, especially for unmatched track and album counts.

- **Documentation**
  - Updated component prop interfaces to reflect new features and usage patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->