### PR TITLE
added progress stats in transfer cta

### DIFF
--- a/apps/web/messages/de.json
+++ b/apps/web/messages/de.json
@@ -305,7 +305,7 @@
     "close": "Schließen"
   },
   "TransferButton": {
-    "findingMatches": "Suche Übereinstimmungen...",
+    "findingMatches": "Übereinstimmungen...",
     "transferring": "Übertrage...",
     "startTransfer": "Übertragung Starten",
     "likedTracks": "Lieblingssongs",

--- a/apps/web/messages/es.json
+++ b/apps/web/messages/es.json
@@ -302,7 +302,7 @@
     "close": "Cerrar"
   },
   "TransferButton": {
-    "findingMatches": "Buscando Coincidencias...",
+    "findingMatches": "Coincidencias...",
     "transferring": "Transfiriendo...",
     "startTransfer": "Iniciar Transferencia",
     "likedTracks": "canciones favoritas",

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -306,9 +306,9 @@
     "close": "Fermer"
   },
   "TransferButton": {
-    "findingMatches": "Recherche de correspondances...",
+    "findingMatches": "Correspondances...",
     "transferring": "Transfert en cours...",
-    "startTransfer": "Commencer le transfert",
+    "startTransfer": "Lancer le transfert",
     "likedTracks": "titres aimés",
     "albums": "albums",
     "playlists": "playlists",

--- a/apps/web/messages/it.json
+++ b/apps/web/messages/it.json
@@ -304,7 +304,7 @@
     "close": "Chiudi"
   },
   "TransferButton": {
-    "findingMatches": "Ricerca Corrispondenze...",
+    "findingMatches": "Corrispondenze...",
     "transferring": "Trasferimento...",
     "startTransfer": "Inizia Trasferimento",
     "likedTracks": "brani preferiti",

--- a/apps/web/messages/pt.json
+++ b/apps/web/messages/pt.json
@@ -303,7 +303,7 @@
     "close": "Fechar"
   },
   "TransferButton": {
-    "findingMatches": "Encontrando Correspondências...",
+    "findingMatches": "Correspondências...",
     "transferring": "Transferindo...",
     "startTransfer": "Iniciar Transferência",
     "likedTracks": "faixas curtidas",

--- a/apps/web/src/__tests__/services/apple/api.test.ts
+++ b/apps/web/src/__tests__/services/apple/api.test.ts
@@ -53,6 +53,29 @@ describe("Apple Music API Service", () => {
     expect(result.added).toBe(mockTracks.length);
   });
 
+  it("createPlaylistWithTracks calls onProgress callback with progress updates", async () => {
+    const tracksWithTargetId = mockTracks.map(t => ({ ...t, targetId: t.id }));
+    const onProgress = vi.fn();
+
+    const result = await api.createPlaylistWithTracks(
+      "Test Playlist",
+      tracksWithTargetId,
+      undefined,
+      onProgress
+    );
+
+    expect(result.playlistId).toBe("new_apple_playlist_id");
+    expect(onProgress).toHaveBeenCalled();
+    expect(onProgress.mock.calls.length).toBeGreaterThan(0);
+
+    // Verify progress values are numbers and in valid range
+    for (const call of onProgress.mock.calls) {
+      expect(typeof call[0]).toBe("number");
+      expect(call[0]).toBeGreaterThan(0);
+      expect(call[0]).toBeLessThanOrEqual(mockTracks.length);
+    }
+  });
+
   it("addTracksToLibrary returns correct counts", async () => {
     const tracksWithTargetId = mockTracks.map(t => ({ ...t, targetId: t.id }));
     const result = await api.addTracksToLibrary(tracksWithTargetId);

--- a/apps/web/src/__tests__/services/spotify/api.test.ts
+++ b/apps/web/src/__tests__/services/spotify/api.test.ts
@@ -54,6 +54,29 @@ describe("Spotify API Service", () => {
     expect(result.added).toBe(mockTracks.length);
   });
 
+  it("createPlaylistWithTracks calls onProgress callback with progress updates", async () => {
+    const tracksWithTargetId = mockTracks.map(t => ({ ...t, targetId: t.id }));
+    const onProgress = vi.fn();
+
+    const result = await api.createPlaylistWithTracks(
+      "Test Playlist",
+      tracksWithTargetId,
+      undefined,
+      onProgress
+    );
+
+    expect(result.playlistId).toBe("new_playlist_id");
+    expect(onProgress).toHaveBeenCalled();
+    expect(onProgress.mock.calls.length).toBeGreaterThan(0);
+
+    // Verify progress values are numbers and in valid range
+    for (const call of onProgress.mock.calls) {
+      expect(typeof call[0]).toBe("number");
+      expect(call[0]).toBeGreaterThan(0);
+      expect(call[0]).toBeLessThanOrEqual(mockTracks.length);
+    }
+  });
+
   it("addTracksToLibrary returns correct counts", async () => {
     const tracksWithTargetId = mockTracks.map(t => ({ ...t, targetId: t.id }));
     const result = await api.addTracksToLibrary(tracksWithTargetId);

--- a/apps/web/src/__tests__/services/youtube/api.test.ts
+++ b/apps/web/src/__tests__/services/youtube/api.test.ts
@@ -54,6 +54,29 @@ describe("YouTube Music API Service", () => {
     expect(result.added).toBe(mockTracks.length);
   });
 
+  it("createPlaylistWithTracks calls onProgress callback with progress updates", async () => {
+    const tracksWithTargetId = mockTracks.map(t => ({ ...t, targetId: t.id }));
+    const onProgress = vi.fn();
+
+    const result = await api.createPlaylistWithTracks(
+      "Test Playlist",
+      tracksWithTargetId,
+      undefined,
+      onProgress
+    );
+
+    expect(result.playlistId).toBe("new_youtube_playlist_id");
+    expect(onProgress).toHaveBeenCalled();
+    expect(onProgress.mock.calls.length).toBeGreaterThan(0);
+
+    // Verify progress values are numbers and in valid range
+    for (const call of onProgress.mock.calls) {
+      expect(typeof call[0]).toBe("number");
+      expect(call[0]).toBeGreaterThan(0);
+      expect(call[0]).toBeLessThanOrEqual(mockTracks.length);
+    }
+  });
+
   it("addTracksToLibrary returns correct counts", async () => {
     const tracksWithTargetId = mockTracks.map(t => ({ ...t, targetId: t.id }));
     const result = await api.addTracksToLibrary(tracksWithTargetId);

--- a/apps/web/src/hooks/useMatching.ts
+++ b/apps/web/src/hooks/useMatching.ts
@@ -116,13 +116,15 @@ export const useMatching = (): UseMatchingReturn => {
         });
         if (result.albums) {
           // Batch update: merge all result.albums into state.albums
+          // Create a map using source album ID as key to preserve individual targetIds
           const updatedAlbumsMap = new Map(result.albums.map(album => [album.id, album]));
           const updated = new Set(
-            Array.from(state.albums ?? []).map(album =>
-              updatedAlbumsMap.has(album.id)
-                ? { ...album, ...updatedAlbumsMap.get(album.id) }
-                : album
-            )
+            Array.from(state.albums ?? []).map(album => {
+              const matchedAlbum = updatedAlbumsMap.get(album.id);
+              return matchedAlbum
+                ? { ...album, targetId: matchedAlbum.targetId, status: matchedAlbum.status }
+                : album;
+            })
           );
           actions.setAlbums(updated);
         }

--- a/apps/web/src/hooks/useTransfer.ts
+++ b/apps/web/src/hooks/useTransfer.ts
@@ -101,7 +101,7 @@ export function useTransfer(): UseTransferHookReturn {
 
       if (matchedLikedSongs.length > 0) {
         const baseProgress = currentProgress;
-        results.likedSongs = await addTracksToLibrary(matchedLikedSongs, completed => {
+        results.likedSongs = await addTracksToLibrary(matchedLikedSongs, (completed, _total) => {
           setTransferProgress({ current: baseProgress + completed, total: totalTracksToTransfer });
         });
         currentProgress += matchedLikedSongs.length;
@@ -119,7 +119,7 @@ export function useTransfer(): UseTransferHookReturn {
       if (albumsWithIds.length > 0) {
         const albumsSet = new Set<IAlbum>(albumsWithIds);
         const baseProgress = currentProgress;
-        results.albums = await addAlbumsToLibrary(albumsSet, completed => {
+        results.albums = await addAlbumsToLibrary(albumsSet, (completed, _total) => {
           setTransferProgress({ current: baseProgress + completed, total: totalTracksToTransfer });
         });
         // Count albums as tracks for progress (as requested for simplicity)
@@ -150,13 +150,11 @@ export function useTransfer(): UseTransferHookReturn {
             playlist.name,
             matchedTracks,
             `Imported from ${sourceService} on ${new Date().toLocaleDateString()}`,
-            completed => {
-              setTimeout(() => {
-                setTransferProgress({
-                  current: baseProgress + completed,
-                  total: totalTracksToTransfer,
-                });
-              }, 0);
+            (completed, _total) => {
+              setTransferProgress({
+                current: baseProgress + completed,
+                total: totalTracksToTransfer,
+              });
             }
           );
           results.playlists.set(playlistId, result);

--- a/apps/web/src/lib/musicApi.ts
+++ b/apps/web/src/lib/musicApi.ts
@@ -78,7 +78,7 @@ export async function fetchPlaylistTracks(
 
 export async function addTracksToLibrary(
   tracks: ITrack[],
-  onProgress?: (completed: number) => void
+  onProgress?: (completed: number, total: number) => void
 ): Promise<TransferResult> {
   const provider = await getCurrentService("target");
   return provider.addTracksToLibrary(tracks, onProgress);
@@ -88,7 +88,7 @@ export async function createPlaylistWithTracks(
   name: string,
   tracks: ITrack[],
   description?: string,
-  onProgress?: (completed: number) => void
+  onProgress?: (completed: number, total: number) => void
 ): Promise<TransferResult> {
   const provider = await getCurrentService("target");
   return provider.createPlaylistWithTracks(name, tracks, description, onProgress);
@@ -96,7 +96,7 @@ export async function createPlaylistWithTracks(
 
 export async function addAlbumsToLibrary(
   albums: Set<IAlbum>,
-  onProgress?: (completed: number) => void
+  onProgress?: (completed: number, total: number) => void
 ): Promise<TransferResult> {
   const provider = await getCurrentService("target");
   return provider.addAlbumsToLibrary(albums, onProgress);

--- a/apps/web/src/lib/musicApi.ts
+++ b/apps/web/src/lib/musicApi.ts
@@ -76,23 +76,30 @@ export async function fetchPlaylistTracks(
   return provider.fetchPlaylistTracks(playlistId, onProgress);
 }
 
-export async function addTracksToLibrary(tracks: ITrack[]): Promise<TransferResult> {
+export async function addTracksToLibrary(
+  tracks: ITrack[],
+  onProgress?: (completed: number) => void
+): Promise<TransferResult> {
   const provider = await getCurrentService("target");
-  return provider.addTracksToLibrary(tracks);
+  return provider.addTracksToLibrary(tracks, onProgress);
 }
 
 export async function createPlaylistWithTracks(
   name: string,
   tracks: ITrack[],
-  description?: string
+  description?: string,
+  onProgress?: (completed: number) => void
 ): Promise<TransferResult> {
   const provider = await getCurrentService("target");
-  return provider.createPlaylistWithTracks(name, tracks, description);
+  return provider.createPlaylistWithTracks(name, tracks, description, onProgress);
 }
 
-export async function addAlbumsToLibrary(albums: Set<IAlbum>): Promise<TransferResult> {
+export async function addAlbumsToLibrary(
+  albums: Set<IAlbum>,
+  onProgress?: (completed: number) => void
+): Promise<TransferResult> {
   const provider = await getCurrentService("target");
-  return provider.addAlbumsToLibrary(albums);
+  return provider.addAlbumsToLibrary(albums, onProgress);
 }
 
 export async function getLibraryData(): Promise<ILibraryData> {

--- a/apps/web/src/lib/services/apple/api.ts
+++ b/apps/web/src/lib/services/apple/api.ts
@@ -451,7 +451,8 @@ export async function search(
 export async function createPlaylistWithTracks(
   name: string,
   tracks: Array<ITrack>,
-  description?: string
+  description?: string,
+  onProgress?: (completed: number) => void
 ): Promise<TransferResult> {
   const authData = await getAppleAuthData("target");
   if (!authData) {
@@ -500,26 +501,43 @@ export async function createPlaylistWithTracks(
     };
   }
 
-  // Add tracks to playlist
-  await retryWithExponentialBackoff(
-    () =>
-      fetchAppleMusic(
-        `${BASE_URL}/v1/me/library/playlists/${playlistId}/tracks`,
-        {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({
-            data: tracksWithIds.map(track => ({
-              id: track.targetId,
-              type: "songs",
-            })),
-          }),
-        },
-        authData
-      ),
-    APPLE_RETRY_OPTIONS
+  // Add tracks to playlist in batches for progress tracking
+  let completedTracks = 0;
+
+  await processInBatches(
+    async batch => {
+      await retryWithExponentialBackoff(
+        () =>
+          fetchAppleMusic(
+            `${BASE_URL}/v1/me/library/playlists/${playlistId}/tracks`,
+            {
+              method: "POST",
+              headers: {
+                "Content-Type": "application/json",
+              },
+              body: JSON.stringify({
+                data: batch.map(track => ({
+                  id: track.targetId,
+                  type: "songs",
+                })),
+              }),
+            },
+            authData
+          ),
+        APPLE_RETRY_OPTIONS
+      );
+
+      // Update progress after each batch
+      completedTracks += batch.length;
+      if (onProgress) {
+        onProgress(completedTracks);
+      }
+    },
+    {
+      items: tracksWithIds,
+      batchSize: 5, // Small batches for granular progress
+      onBatchStart: () => {},
+    }
   );
 
   return {
@@ -530,7 +548,10 @@ export async function createPlaylistWithTracks(
   };
 }
 
-export async function addTracksToLibrary(tracks: Array<ITrack>): Promise<TransferResult> {
+export async function addTracksToLibrary(
+  tracks: Array<ITrack>,
+  onProgress?: (completed: number) => void
+): Promise<TransferResult> {
   const authData = await getAppleAuthData("target");
   if (!authData) {
     throw new Error("Not authenticated with Apple Music");
@@ -550,26 +571,43 @@ export async function addTracksToLibrary(tracks: Array<ITrack>): Promise<Transfe
     };
   }
 
-  // Add tracks to library with retry
-  await retryWithExponentialBackoff(
-    () =>
-      fetchAppleMusic(
-        `${BASE_URL}/v1/me/library`,
-        {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({
-            data: tracksWithIds.map(track => ({
-              id: track.targetId,
-              type: "songs",
-            })),
-          }),
-        },
-        authData
-      ),
-    APPLE_RETRY_OPTIONS
+  // Add tracks to library in batches for progress tracking
+  let completedTracks = 0;
+
+  await processInBatches(
+    async batch => {
+      await retryWithExponentialBackoff(
+        () =>
+          fetchAppleMusic(
+            `${BASE_URL}/v1/me/library`,
+            {
+              method: "POST",
+              headers: {
+                "Content-Type": "application/json",
+              },
+              body: JSON.stringify({
+                data: batch.map(track => ({
+                  id: track.targetId,
+                  type: "songs",
+                })),
+              }),
+            },
+            authData
+          ),
+        APPLE_RETRY_OPTIONS
+      );
+
+      // Update progress after each batch
+      completedTracks += batch.length;
+      if (onProgress) {
+        onProgress(completedTracks);
+      }
+    },
+    {
+      items: tracksWithIds,
+      batchSize: 5, // Small batches for granular progress
+      onBatchStart: () => {},
+    }
   );
 
   return {
@@ -580,7 +618,10 @@ export async function addTracksToLibrary(tracks: Array<ITrack>): Promise<Transfe
   };
 }
 
-export async function addAlbumsToLibrary(albums: Set<IAlbum>): Promise<TransferResult> {
+export async function addAlbumsToLibrary(
+  albums: Set<IAlbum>,
+  onProgress?: (completed: number) => void
+): Promise<TransferResult> {
   const authData = await getAppleAuthData("target");
   if (!authData) {
     throw new Error("Not authenticated with Apple Music");
@@ -595,27 +636,71 @@ export async function addAlbumsToLibrary(albums: Set<IAlbum>): Promise<TransferR
     };
   }
 
-  // Construct the URL with comma-separated album IDs
-  const albumIds = Array.from(albums)
-    .map(album => album.targetId)
-    .join(",");
-  const url = `${BASE_URL}/v1/me/library?ids[albums]=${albumIds}`;
+  // Add albums to library in batches for progress tracking
+  const albumsWithIds = Array.from(albums).filter(album => album.targetId);
 
-  // Add albums to library with retry
-  await retryWithExponentialBackoff(
-    () =>
-      fetchAppleMusic(
-        url,
-        {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
+  let completedAlbums = 0;
+
+  // Process each album individually for progress tracking
+  for (let i = 0; i < albumsWithIds.length; i++) {
+    const album = albumsWithIds[i];
+    const url = `${BASE_URL}/v1/me/library?ids[albums]=${album.targetId}`;
+
+    // Handle Apple Music's empty 202 responses manually to avoid JSON parsing errors
+    let attempt = 0;
+    const maxRetries = APPLE_RETRY_OPTIONS.maxRetries || 3;
+
+    while (attempt <= maxRetries) {
+      try {
+        const response = await fetchAppleMusic(
+          url,
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+            },
           },
-        },
-        authData
-      ),
-    APPLE_RETRY_OPTIONS
-  );
+          authData
+        );
+
+        // Apple Music returns empty 202 responses for successful album additions
+        if (response.ok) {
+          break; // Success - exit the retry loop
+        } else if (response.status === 429 || response.status >= 500) {
+          // Retryable error
+          if (attempt === maxRetries) {
+            throw new Error(
+              `Apple Music API error after ${maxRetries} retries: ${response.status} ${response.statusText}`
+            );
+          }
+          const delay = Math.min(1000 * 2 ** attempt, 16000);
+          await new Promise(resolve => setTimeout(resolve, delay));
+          attempt++;
+        } else {
+          // Non-retryable error
+          throw new Error(`Apple Music API error: ${response.status} ${response.statusText}`);
+        }
+      } catch (error) {
+        if (attempt === maxRetries) {
+          throw error;
+        }
+        const delay = Math.min(1000 * 2 ** attempt, 16000);
+        await new Promise(resolve => setTimeout(resolve, delay));
+        attempt++;
+      }
+    }
+
+    // Update progress after each album
+    completedAlbums++;
+    if (onProgress) {
+      onProgress(completedAlbums);
+    }
+
+    // Small delay between requests to avoid rate limiting
+    if (i < albumsWithIds.length - 1) {
+      await new Promise(resolve => setTimeout(resolve, 10));
+    }
+  }
 
   return {
     added: albums.size,

--- a/apps/web/src/lib/services/apple/api.ts
+++ b/apps/web/src/lib/services/apple/api.ts
@@ -452,7 +452,7 @@ export async function createPlaylistWithTracks(
   name: string,
   tracks: Array<ITrack>,
   description?: string,
-  onProgress?: (completed: number) => void
+  onProgress?: (completed: number, total: number) => void
 ): Promise<TransferResult> {
   const authData = await getAppleAuthData("target");
   if (!authData) {
@@ -503,6 +503,7 @@ export async function createPlaylistWithTracks(
 
   // Add tracks to playlist in batches for progress tracking
   let completedTracks = 0;
+  const total = tracksWithIds.length;
 
   await processInBatches(
     async batch => {
@@ -530,7 +531,7 @@ export async function createPlaylistWithTracks(
       // Update progress after each batch
       completedTracks += batch.length;
       if (onProgress) {
-        onProgress(completedTracks);
+        onProgress(completedTracks, total);
       }
     },
     {
@@ -550,7 +551,7 @@ export async function createPlaylistWithTracks(
 
 export async function addTracksToLibrary(
   tracks: Array<ITrack>,
-  onProgress?: (completed: number) => void
+  onProgress?: (completed: number, total: number) => void
 ): Promise<TransferResult> {
   const authData = await getAppleAuthData("target");
   if (!authData) {
@@ -573,6 +574,7 @@ export async function addTracksToLibrary(
 
   // Add tracks to library in batches for progress tracking
   let completedTracks = 0;
+  const total = tracksWithIds.length;
 
   await processInBatches(
     async batch => {
@@ -600,7 +602,7 @@ export async function addTracksToLibrary(
       // Update progress after each batch
       completedTracks += batch.length;
       if (onProgress) {
-        onProgress(completedTracks);
+        onProgress(completedTracks, total);
       }
     },
     {
@@ -620,7 +622,7 @@ export async function addTracksToLibrary(
 
 export async function addAlbumsToLibrary(
   albums: Set<IAlbum>,
-  onProgress?: (completed: number) => void
+  onProgress?: (completed: number, total: number) => void
 ): Promise<TransferResult> {
   const authData = await getAppleAuthData("target");
   if (!authData) {
@@ -640,6 +642,7 @@ export async function addAlbumsToLibrary(
   const albumsWithIds = Array.from(albums).filter(album => album.targetId);
 
   let completedAlbums = 0;
+  const total = albumsWithIds.length;
 
   // Process each album individually for progress tracking
   for (let i = 0; i < albumsWithIds.length; i++) {
@@ -693,7 +696,7 @@ export async function addAlbumsToLibrary(
     // Update progress after each album
     completedAlbums++;
     if (onProgress) {
-      onProgress(completedAlbums);
+      onProgress(completedAlbums, total);
     }
 
     // Small delay between requests to avoid rate limiting

--- a/apps/web/src/lib/services/deezer/api.ts
+++ b/apps/web/src/lib/services/deezer/api.ts
@@ -311,7 +311,10 @@ export async function searchAlbums(
 /**
  * Empty implementation for addTracksToLibrary - Deezer API not supported
  */
-export async function addTracksToLibrary(tracks: ITrack[]): Promise<TransferResult> {
+export async function addTracksToLibrary(
+  tracks: ITrack[],
+  _onProgress?: (completed: number) => void
+): Promise<TransferResult> {
   return {
     added: 0,
     failed: tracks.length,
@@ -323,7 +326,10 @@ export async function addTracksToLibrary(tracks: ITrack[]): Promise<TransferResu
 /**
  * Empty implementation for addAlbumsToLibrary - Deezer API not supported
  */
-export async function addAlbumsToLibrary(albums: Set<IAlbum>): Promise<TransferResult> {
+export async function addAlbumsToLibrary(
+  albums: Set<IAlbum>,
+  _onProgress?: (completed: number) => void
+): Promise<TransferResult> {
   return {
     added: 0,
     failed: albums.size,
@@ -338,7 +344,8 @@ export async function addAlbumsToLibrary(albums: Set<IAlbum>): Promise<TransferR
 export async function createPlaylistWithTracks(
   _name: string,
   _tracks: ITrack[],
-  _description?: string
+  _description?: string,
+  _onProgress?: (completed: number) => void
 ): Promise<TransferResult> {
   return {
     added: 0,

--- a/apps/web/src/lib/services/deezer/api.ts
+++ b/apps/web/src/lib/services/deezer/api.ts
@@ -313,7 +313,7 @@ export async function searchAlbums(
  */
 export async function addTracksToLibrary(
   tracks: ITrack[],
-  _onProgress?: (completed: number) => void
+  _onProgress?: (completed: number, total: number) => void
 ): Promise<TransferResult> {
   return {
     added: 0,
@@ -328,7 +328,7 @@ export async function addTracksToLibrary(
  */
 export async function addAlbumsToLibrary(
   albums: Set<IAlbum>,
-  _onProgress?: (completed: number) => void
+  _onProgress?: (completed: number, total: number) => void
 ): Promise<TransferResult> {
   return {
     added: 0,
@@ -345,7 +345,7 @@ export async function createPlaylistWithTracks(
   _name: string,
   _tracks: ITrack[],
   _description?: string,
-  _onProgress?: (completed: number) => void
+  _onProgress?: (completed: number, total: number) => void
 ): Promise<TransferResult> {
   return {
     added: 0,

--- a/apps/web/src/lib/services/youtube/api.ts
+++ b/apps/web/src/lib/services/youtube/api.ts
@@ -239,7 +239,7 @@ export async function createPlaylistWithTracks(
   name: string,
   tracks: ITrack[],
   description?: string,
-  onProgress?: (completed: number) => void
+  onProgress?: (completed: number, total: number) => void
 ): Promise<TransferResult> {
   const authData = await getYouTubeAuthData("target");
   if (!authData) throw new Error("Not authenticated with YouTube");
@@ -277,6 +277,7 @@ export async function createPlaylistWithTracks(
 
   // Add tracks to the playlist in batches, using retryWithExponentialBackoff for each request
   let completedTracks = 0;
+  const total = validTracks.length;
 
   const result = await processInBatches(
     async batch => {
@@ -315,7 +316,7 @@ export async function createPlaylistWithTracks(
       // Update progress after each batch
       completedTracks += batch.length;
       if (onProgress) {
-        onProgress(completedTracks);
+        onProgress(completedTracks, total);
       }
     },
     {
@@ -784,7 +785,7 @@ export async function searchAlbums(
  */
 export async function addTracksToLibrary(
   tracks: ITrack[],
-  onProgress?: (completed: number) => void
+  onProgress?: (completed: number, total: number) => void
 ): Promise<TransferResult> {
   const authData = await getYouTubeAuthData("target");
   if (!authData) {
@@ -820,7 +821,7 @@ export async function addTracksToLibrary(
 
 export async function addAlbumsToLibrary(
   _albums: Set<IAlbum>,
-  _onProgress?: (completed: number) => void
+  _onProgress?: (completed: number, total: number) => void
 ): Promise<TransferResult> {
   // no way to add albums to YouTube Music library yet
   return {

--- a/apps/web/src/lib/services/youtube/api.ts
+++ b/apps/web/src/lib/services/youtube/api.ts
@@ -238,7 +238,8 @@ export async function search(
 export async function createPlaylistWithTracks(
   name: string,
   tracks: ITrack[],
-  description?: string
+  description?: string,
+  onProgress?: (completed: number) => void
 ): Promise<TransferResult> {
   const authData = await getYouTubeAuthData("target");
   if (!authData) throw new Error("Not authenticated with YouTube");
@@ -275,6 +276,8 @@ export async function createPlaylistWithTracks(
   const playlistId = playlistData.id;
 
   // Add tracks to the playlist in batches, using retryWithExponentialBackoff for each request
+  let completedTracks = 0;
+
   const result = await processInBatches(
     async batch => {
       await Promise.all(
@@ -308,10 +311,16 @@ export async function createPlaylistWithTracks(
             }
           })
       );
+
+      // Update progress after each batch
+      completedTracks += batch.length;
+      if (onProgress) {
+        onProgress(completedTracks);
+      }
     },
     {
       items: validTracks,
-      batchSize: 1,
+      batchSize: 2, // Small batches for granular progress
       delayBetweenBatches: 200,
       onBatchStart: () => {},
     }
@@ -773,7 +782,10 @@ export async function searchAlbums(
 /**
  * Add tracks to YouTube Music library
  */
-export async function addTracksToLibrary(tracks: ITrack[]): Promise<TransferResult> {
+export async function addTracksToLibrary(
+  tracks: ITrack[],
+  onProgress?: (completed: number) => void
+): Promise<TransferResult> {
   const authData = await getYouTubeAuthData("target");
   if (!authData) {
     throw new Error("Not authenticated with YouTube");
@@ -791,7 +803,12 @@ export async function addTracksToLibrary(tracks: ITrack[]): Promise<TransferResu
 
   // Create a playlist for the tracks
   const playlistName = `Imported from Nonna.fm - ${new Date().toLocaleDateString()}`;
-  const playlistId = await createPlaylistWithTracks(playlistName, validTracks);
+  const playlistId = await createPlaylistWithTracks(
+    playlistName,
+    validTracks,
+    undefined,
+    onProgress
+  );
 
   return {
     added: validTracks.length,
@@ -801,7 +818,10 @@ export async function addTracksToLibrary(tracks: ITrack[]): Promise<TransferResu
   };
 }
 
-export async function addAlbumsToLibrary(_albums: Set<IAlbum>): Promise<TransferResult> {
+export async function addAlbumsToLibrary(
+  _albums: Set<IAlbum>,
+  _onProgress?: (completed: number) => void
+): Promise<TransferResult> {
   // no way to add albums to YouTube Music library yet
   return {
     added: 0,

--- a/apps/web/src/types/services.ts
+++ b/apps/web/src/types/services.ts
@@ -31,19 +31,19 @@ export interface IMusicServiceProvider {
 
   addTracksToLibrary: (
     tracks: Array<ITrack>,
-    onProgress?: (completed: number) => void
+    onProgress?: (completed: number, total: number) => void
   ) => Promise<TransferResult>;
 
   addAlbumsToLibrary: (
     albums: Set<IAlbum>,
-    onProgress?: (completed: number) => void
+    onProgress?: (completed: number, total: number) => void
   ) => Promise<TransferResult>;
 
   createPlaylistWithTracks: (
     name: string,
     tracks: Array<ITrack>,
     description?: string,
-    onProgress?: (completed: number) => void
+    onProgress?: (completed: number, total: number) => void
   ) => Promise<TransferResult>;
 
   fetchUserLibrary: () => Promise<ILibraryData>;

--- a/apps/web/src/types/services.ts
+++ b/apps/web/src/types/services.ts
@@ -29,14 +29,21 @@ export interface IMusicServiceProvider {
     onProgress?: (progress: number) => void
   ) => Promise<SearchResult>;
 
-  addTracksToLibrary: (tracks: Array<ITrack>) => Promise<TransferResult>;
+  addTracksToLibrary: (
+    tracks: Array<ITrack>,
+    onProgress?: (completed: number) => void
+  ) => Promise<TransferResult>;
 
-  addAlbumsToLibrary: (albums: Set<IAlbum>) => Promise<TransferResult>;
+  addAlbumsToLibrary: (
+    albums: Set<IAlbum>,
+    onProgress?: (completed: number) => void
+  ) => Promise<TransferResult>;
 
   createPlaylistWithTracks: (
     name: string,
     tracks: Array<ITrack>,
-    description?: string
+    description?: string,
+    onProgress?: (completed: number) => void
   ) => Promise<TransferResult>;
 
   fetchUserLibrary: () => Promise<ILibraryData>;

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "lint:fix": "biome lint --write .",
     "check": "biome check .",
     "check:fix": "biome check --write .",
+    "biome:ci": "biome ci",
     "update-deps": "syncpack update",
     "check-deps": "syncpack list-mismatches",
     "fix-deps": "syncpack fix-mismatches",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Live transfer progress across services; transfer button shows “transferring (current/total)” and finer-grained progress during transfers.
- **Bug Fixes**
  - Improved album matching updates to avoid overwriting unrelated fields.
- **Style**
  - Transfer button uses a flexible min-width for better responsiveness.
- **Localization**
  - Updated transfer-related labels in German, Spanish, French, Italian, and Portuguese.
- **Tests**
  - Added progress-callback tests for Apple Music, Spotify, and YouTube.
- **Chores**
  - Added a CI script for biome linting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->